### PR TITLE
feat: add science card with Pomodoro research blurb and bibliography

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -26,6 +26,21 @@
       </div>
         <h1 class="title">Pomodoro Timer</h1>
       <p class="subtitle">For creators who code in daylight and pray at midnight.</p>
+
+        <div class="science-card" aria-label="The science behind Pomodoro">
+          <p class="science-card__eyebrow">Why it works</p>
+          <ul class="science-card__list">
+            <li><strong>Breaks prevent attention collapse.</strong> Mandatory short intervals keep the brain re-engaging with the goal, staving off vigilance decrements that compound over long unbroken sessions.</li>
+            <li><strong>Structure dismantles procrastination.</strong> Procrastination is primarily a self-regulation failure. Fixed time-boxes lower the activation energy to start by shrinking the perceived commitment.</li>
+            <li><strong>Intervals encode memory more deeply.</strong> Distributed practice — working in spaced, separated bursts — produces stronger long-term retention than equivalent massed study.</li>
+          </ul>
+          <ol class="science-card__bib">
+            <li>Ariga, A., &amp; Lleras, A. (2011). Brief and rare mental "breaks" keep you focused: Deactivation and reactivation of task goals preempt vigilance decrements. <em>Cognition, 118</em>(3), 439–443. <a class="science-card__link" href="https://doi.org/10.1016/j.cognition.2010.12.007" target="_blank" rel="noopener noreferrer">doi:10.1016/j.cognition.2010.12.007</a></li>
+            <li>Steel, P. (2007). The nature of procrastination: A meta-analytic and theoretical review of quintessential self-regulatory failure. <em>Psychological Bulletin, 133</em>(1), 65–94. <a class="science-card__link" href="https://doi.org/10.1037/0033-2909.133.1.065" target="_blank" rel="noopener noreferrer">doi:10.1037/0033-2909.133.1.065</a></li>
+            <li>Cepeda, N. J., Pashler, H., Vul, E., Wixted, J. T., &amp; Rohrer, D. (2006). Distributed practice in verbal recall tasks: A review and quantitative synthesis. <em>Psychological Bulletin, 132</em>(3), 354–380. <a class="science-card__link" href="https://doi.org/10.1037/0033-2909.132.3.354" target="_blank" rel="noopener noreferrer">doi:10.1037/0033-2909.132.3.354</a></li>
+          </ol>
+        </div>
+
         <div class="rail-bottom">
           <p class="rail-note">Issue 01 · Ritual Edition</p>
           <button class="install-btn" id="install-btn" type="button" hidden>Install app</button>

--- a/docs/style.css
+++ b/docs/style.css
@@ -203,6 +203,86 @@ body[data-theme="emerald-night"] .theme-toggle:hover {
     max-width: 32ch;
 }
 
+/* ── Science card ───────────────────────────────────── */
+.science-card {
+    margin-top: 1.6rem;
+    padding: 1.1rem 1.2rem 1.2rem;
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    background: rgba(20, 15, 12, 0.03);
+    max-width: 36ch;
+}
+
+body[data-theme="burgundy-night"] .science-card,
+body[data-theme="emerald-night"] .science-card {
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.science-card__eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-size: 0.62rem;
+    font-weight: 700;
+    color: var(--muted-ink);
+    margin-bottom: 0.75rem;
+}
+
+.science-card__list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+}
+
+.science-card__list li {
+    font-size: 0.82rem;
+    line-height: 1.6;
+    color: var(--ink);
+    padding-left: 1.1em;
+    position: relative;
+}
+
+.science-card__list li::before {
+    content: "–";
+    position: absolute;
+    left: 0;
+    color: var(--muted-ink);
+}
+
+.science-card__bib {
+    margin: 0;
+    padding-left: 1.4em;
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    border-top: 1px solid var(--line);
+    padding-top: 0.85rem;
+}
+
+.science-card__bib li {
+    font-size: 0.72rem;
+    line-height: 1.65;
+    color: var(--muted-ink);
+}
+
+.science-card__bib em {
+    font-style: italic;
+}
+
+.science-card__link {
+    color: var(--muted-ink);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    word-break: break-all;
+}
+
+.science-card__link:hover {
+    color: var(--ink);
+}
+
+/* ── Rail bottom ─────────────────────────────────────── */
 .rail-bottom {
     margin-top: auto;
     padding-top: 1.6rem;

--- a/index.html
+++ b/index.html
@@ -26,6 +26,21 @@
       </div>
         <h1 class="title">Pomodoro Timer</h1>
       <p class="subtitle">For creators who code in daylight and pray at midnight.</p>
+
+        <div class="science-card" aria-label="The science behind Pomodoro">
+          <p class="science-card__eyebrow">Why it works</p>
+          <ul class="science-card__list">
+            <li><strong>Breaks prevent attention collapse.</strong> Mandatory short intervals keep the brain re-engaging with the goal, staving off vigilance decrements that compound over long unbroken sessions.</li>
+            <li><strong>Structure dismantles procrastination.</strong> Procrastination is primarily a self-regulation failure. Fixed time-boxes lower the activation energy to start by shrinking the perceived commitment.</li>
+            <li><strong>Intervals encode memory more deeply.</strong> Distributed practice — working in spaced, separated bursts — produces stronger long-term retention than equivalent massed study.</li>
+          </ul>
+          <ol class="science-card__bib">
+            <li>Ariga, A., &amp; Lleras, A. (2011). Brief and rare mental "breaks" keep you focused: Deactivation and reactivation of task goals preempt vigilance decrements. <em>Cognition, 118</em>(3), 439–443. <a class="science-card__link" href="https://doi.org/10.1016/j.cognition.2010.12.007" target="_blank" rel="noopener noreferrer">doi:10.1016/j.cognition.2010.12.007</a></li>
+            <li>Steel, P. (2007). The nature of procrastination: A meta-analytic and theoretical review of quintessential self-regulatory failure. <em>Psychological Bulletin, 133</em>(1), 65–94. <a class="science-card__link" href="https://doi.org/10.1037/0033-2909.133.1.065" target="_blank" rel="noopener noreferrer">doi:10.1037/0033-2909.133.1.065</a></li>
+            <li>Cepeda, N. J., Pashler, H., Vul, E., Wixted, J. T., &amp; Rohrer, D. (2006). Distributed practice in verbal recall tasks: A review and quantitative synthesis. <em>Psychological Bulletin, 132</em>(3), 354–380. <a class="science-card__link" href="https://doi.org/10.1037/0033-2909.132.3.354" target="_blank" rel="noopener noreferrer">doi:10.1037/0033-2909.132.3.354</a></li>
+          </ol>
+        </div>
+
         <div class="rail-bottom">
           <p class="rail-note">Issue 01 · Ritual Edition</p>
           <button class="install-btn" id="install-btn" type="button" hidden>Install app</button>

--- a/style.css
+++ b/style.css
@@ -203,6 +203,86 @@ body[data-theme="emerald-night"] .theme-toggle:hover {
     max-width: 32ch;
 }
 
+/* ── Science card ───────────────────────────────────── */
+.science-card {
+    margin-top: 1.6rem;
+    padding: 1.1rem 1.2rem 1.2rem;
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    background: rgba(20, 15, 12, 0.03);
+    max-width: 36ch;
+}
+
+body[data-theme="burgundy-night"] .science-card,
+body[data-theme="emerald-night"] .science-card {
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.science-card__eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-size: 0.62rem;
+    font-weight: 700;
+    color: var(--muted-ink);
+    margin-bottom: 0.75rem;
+}
+
+.science-card__list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+}
+
+.science-card__list li {
+    font-size: 0.82rem;
+    line-height: 1.6;
+    color: var(--ink);
+    padding-left: 1.1em;
+    position: relative;
+}
+
+.science-card__list li::before {
+    content: "–";
+    position: absolute;
+    left: 0;
+    color: var(--muted-ink);
+}
+
+.science-card__bib {
+    margin: 0;
+    padding-left: 1.4em;
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    border-top: 1px solid var(--line);
+    padding-top: 0.85rem;
+}
+
+.science-card__bib li {
+    font-size: 0.72rem;
+    line-height: 1.65;
+    color: var(--muted-ink);
+}
+
+.science-card__bib em {
+    font-style: italic;
+}
+
+.science-card__link {
+    color: var(--muted-ink);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    word-break: break-all;
+}
+
+.science-card__link:hover {
+    color: var(--ink);
+}
+
+/* ── Rail bottom ─────────────────────────────────────── */
 .rail-bottom {
     margin-top: auto;
     padding-top: 1.6rem;


### PR DESCRIPTION
## Summary

Adds a "Why it works" science card to the editorial rail, directly below the subtitle line. The card gives users context on the research behind the Pomodoro method.

## What Changed

### `index.html` / `docs/index.html`
- New `.science-card` block inserted between the subtitle and `.rail-bottom`.
- Contains three benefit bullets (attention, procrastination, distributed practice) and a ruled bibliography with DOI links for three peer-reviewed sources.

### `style.css` / `docs/style.css`
- New `.science-card` family of styles: card container, eyebrow label, bullet list with dash markers, ruled bibliography section, DOI link hover state.
- Responds correctly to all three themes (light, burgundy-night, emerald-night).

## Sources Cited

1. Ariga & Lleras (2011). *Cognition, 118*(3), 439–443. doi:10.1016/j.cognition.2010.12.007
2. Steel (2007). *Psychological Bulletin, 133*(1), 65–94. doi:10.1037/0033-2909.133.1.065
3. Cepeda et al. (2006). *Psychological Bulletin, 132*(3), 354–380. doi:10.1037/0033-2909.132.3.354

## Test Checklist

- [ ] Science card appears below the subtitle on desktop and mobile.
- [ ] Card border and background adapt to all three themes.
- [ ] DOI links open the correct pages in a new tab.
- [ ] Layout does not break on narrow viewports.